### PR TITLE
Fixes click area for result (record) tabs

### DIFF
--- a/discovere.css
+++ b/discovere.css
@@ -925,24 +925,6 @@ ul.footer-links.footer-links-emory li:hover a,ul.footer-links.footer-links-emory
     height:  auto;
 }
 
-.EXLTabsRibbon div li.EXLResultTab a{
-    color: #002878;
-    padding: .5em;
-}
-
-.EXLTabsRibbon div li.EXLResultSelectedTab {
-    background:  none;
-    border: 1px solid #ccc;
-    border-bottom: none;
-    border-radius: 3px 3px 0 0;
-}
-
-.EXLTabsRibbon div li.EXLResultSelectedTab a {
-    text-decoration: none;
-    color: #333;
-    font-weight: 400;
-}
-
 .EXLResultTabContainer div.EXLTabHeader {
     background:  none;
     border:  1px solid #ccc;
@@ -1150,9 +1132,10 @@ body.EXLFullView div.EXLResultsList h1.EXLResultTitle {
     display: -ms-flexbox;
     display: flex;
     -ms-flex-align: center;
-    align-items: center;
+    align-items: stretch;
+    justify-content: stretch;
     margin: 0;
-    padding: .5em;
+    padding: 0;
     border: 1px solid #ccc;
     border-top-color: #f5f5f5;
     border-left-color: #f5f5f5;
@@ -1176,7 +1159,9 @@ body.EXLFullView div.EXLResultsList h1.EXLResultTitle {
 }
 
 .EXLTabsRibbon div li.EXLResultTab a {
-    text-decoration: none
+    text-decoration: none;
+    color: #002878;
+    padding: 1em;
 }
 
 .EXLTabsRibbon div li.EXLResultTab:hover {
@@ -1186,6 +1171,7 @@ body.EXLFullView div.EXLResultsList h1.EXLResultTitle {
 .EXLTabsRibbon div li.EXLResultTab:hover a {
     color: #fff
 }
+
 .EXLTabsRibbon div {
     width: 100%;
 }
@@ -1196,20 +1182,26 @@ body.EXLFullView div.EXLTabsRibbon {
     padding: 0;
 }
 
+.EXLTabsRibbon div li.EXLResultSelectedTab {
+    background: none;
+    background-color: #6384c6;
+    border: 1px solid #ccc;
+    border-bottom: none;
+    border-radius: 3px 3px 0 0;
+}
+
+.EXLTabsRibbon div li.EXLResultSelectedTab a {
+    color: #fff;
+    text-decoration: none;
+    font-weight: 400;
+}
+
 /* Hidden tabs */
 .EXLTabsRibbon div li.EXLResultTab.EXLReviewsTab, .EXLTabsRibbon div li.EXLResultTab.EXLRecommendTab, .EXLTabsRibbon div li.EXLResultTab.EXLLocationsTab {
     display: none;
 }
 /* ---- */
 
-.EXLTabsRibbon div li.EXLResultSelectedTab {
-    background: #6384c6;
-}
-
-.EXLTabsRibbon div li.EXLResultSelectedTab a {
-    color: #fff;
-    text-decoration: none;
-}
 /* Action/SendTo menu */
 .EXLTabHeader div.EXLTabHeaderButtons li {
     background-image: none;


### PR DESCRIPTION
Tabs were not entirely clickable only linked text; now link fills whole tab.
Consolidates multiple definitions for the duplicate selectors

For demo, see
http://discoveretest.emory.edu/primo_library/libweb/action/display.do?vid=Disco2EB&tabs=detailsTab&ct=display&fn=search&doc=01EMORY_ALMA51273080980002486&indx=1&recIds=01EMORY_ALMA51273080980002486&recIdxs=0&elementId=0&renderMode=poppedOut&displayMode=full&frbrVersion=&frbg=&&dscnt=0&scp.scps=scope%3A%2801EMORY_ALMA%29%2Cscope%3A%28repo%29%2CEmory_PrimoThirdNode&tb=t&vid=discovere&mode=Basic&srt=rank&tab=emory_catalog&vl(28118899UI1)=all_items&dum=true&vl(freeText0)=test&dstmp=1502716953241&wroDevMode=true

Contrast with a record in production