### PR TITLE
Fixes Browse Search Bar Extending Left of page

### DIFF
--- a/css/discovere.css
+++ b/css/discovere.css
@@ -305,7 +305,7 @@ body > div {
     border:  none;
 }
 
-#exlidSearchTileWrapper {
+.EXLCustomLayoutContainer.EXLHeader #exlidSearchTileWrapper {
     flex-basis: 100%;
     margin: 0 .5em;
     /* order: 3; */
@@ -705,7 +705,6 @@ body > div {
         width: 70%;
         border-left: 1px solid #D7DDE3;
         padding-left: 1%;
-        float: right;
     }
     .EXLFacetTile {
         width: 20%;


### PR DESCRIPTION
Fixes #29 

http://discoveretest.emory.edu/primo_library/libweb/action/search.do?fn=showBrowse&mode=BrowseSearch&frbg=&&fn=search&indx=1&dscnt=0&scp.scps=scope%3A(01EMORY_ALMA)%2Cscope%3A(repo)%2CEmory_PrimoThirdNode&tb=t&vid=discovere&ct=search&srt=rank&tab=emory_catalog&vl(28118899UI1)=all_items&dum=true&vl(freeText0)=test&dstmp=1520371430294&wroDevMode=true